### PR TITLE
fix(includes): preserve {{ }} in @include partials that define their own signals (#1758)

### DIFF
--- a/packages/stx/src/expressions.ts
+++ b/packages/stx/src/expressions.ts
@@ -640,7 +640,7 @@ export function interpolateScriptsInTemplate(
 /**
  * Process template expressions including variables, filters, and operations
  */
-export function processExpressions(template: string, context: Record<string, any>, filePath: string): string {
+export function processExpressions(template: string, context: Record<string, any>, filePath: string, options?: { forceSignals?: boolean }): string {
   let output = template
 
   // Protect <style> and <script> blocks that contain NO stx template
@@ -677,8 +677,13 @@ export function processExpressions(template: string, context: Record<string, any
   output = maskInto(output, matchScriptElement, scriptBlocks, n => `<!--__STX_SCRIPT_EXPR_${n}__-->`)
 
   // Check if this template uses signals - if so, we need to preserve expressions
-  // that reference runtime variables (like loop variables or signal calls)
-  const hasSignals = usesSignalsInScript(template)
+  // that reference runtime variables (like loop variables or signal calls).
+  // `forceSignals` is set by the @include path: a partial's <script> is stripped
+  // (includes.ts) before this runs, so usesSignalsInScript(template) can't see its
+  // own state()/derived(). The caller computes the gate on the partial's FULL
+  // content and passes it here, so {{ }} over the partial's own signals are
+  // preserved for the runtime — exactly like a top-level page. See stacksjs/stx#1758.
+  const hasSignals = options?.forceSignals === true || usesSignalsInScript(template)
 
   // Replace triple curly braces with unescaped expressions {{{ expr }}} - similar to {!! expr !!}
   output = output.replace(/\{\{\{([\s\S]*?)\}\}\}/g, (match, expr, offset) => {

--- a/packages/stx/src/includes.ts
+++ b/packages/stx/src/includes.ts
@@ -69,7 +69,7 @@
 import type { StxOptions } from './types'
 import path from 'node:path'
 import { processConditionals } from './conditionals'
-import { processExpressions } from './expressions'
+import { processExpressions, usesSignalsInScript } from './expressions'
 import { LRUCache } from './performance-utils'
 import { createSafeFunction, isExpressionSafe, safeEvaluate, safeEvaluateObject } from './safe-evaluator'
 import { transformStoreImports } from './store-imports'
@@ -1103,8 +1103,17 @@ catch (e) {
       // Process conditionals
       processedContent = processConditionals(processedContent, includeContext, includeFilePath)
 
-      // Process expressions
-      processedContent = processExpressions(processedContent, includeContext, includeFilePath)
+      // Process expressions.
+      // The partial's <script> was stripped above (line ~925) so the style/script
+      // extractors and the parent's client-script pipeline don't double-process it.
+      // That also hides the partial's own state()/derived() from processExpressions'
+      // usesSignalsInScript gate, which would then evaluate `{{ signalCall() }}`
+      // server-side (undefined → emptied) and consume the marker, leaving nothing
+      // for the runtime to bind — the partial renders permanently blank. Recover the
+      // gate from the FULL partial content so a partial with a client signal script
+      // preserves {{ }} just like a top-level page. See stacksjs/stx#1758.
+      const partialHasSignals = usesSignalsInScript(partialContent)
+      processedContent = processExpressions(processedContent, includeContext, includeFilePath, { forceSignals: partialHasSignals })
 
       // Append preserved style and script for SFC support
       if (preservedStyle) {

--- a/packages/stx/test/includes/signal-partial-mustache.test.ts
+++ b/packages/stx/test/includes/signal-partial-mustache.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { processDirectives } from '../../src/process'
+import { cleanupTestDirs, createPartialFile, PARTIALS_DIR, setupTestDirs } from '../utils'
+
+// Regression: stacksjs/stx#1758
+//
+// An @include partial's <script> is stripped (includes.ts) BEFORE its body
+// expressions are processed, so processExpressions' usesSignalsInScript gate
+// can't see the partial's own state()/derived(). Without recovering that gate
+// from the partial's full content, `{{ signalCall() }}` is evaluated
+// server-side (undefined → emptied) and the marker is consumed — the partial
+// renders permanently blank instead of binding on the client.
+//
+// The fix computes usesSignalsInScript on the FULL partial content and passes
+// it to processExpressions as { forceSignals }. These tests pin both the fix
+// (signal partials preserve {{ }}) and that it does NOT over-preserve
+// (server-var / signal-free partials still evaluate server-side).
+//
+// Rendered via src `processDirectives` rather than Bun.build+stxPlugin so the
+// assertions exercise src, not a possibly-stale dist (see test-realm memory).
+describe('stx#1758: {{ }} in @include partials with their own signals', () => {
+  beforeAll(setupTestDirs)
+  afterAll(cleanupTestDirs)
+
+  const opts = { debug: false, partialsDir: PARTIALS_DIR, componentsDir: PARTIALS_DIR } as any
+  const render = (tmpl: string): Promise<string> =>
+    processDirectives(tmpl, {}, 'page.stx', opts, new Set())
+
+  it('preserves {{ signalCall() }} when the partial defines its own signals', async () => {
+    await createPartialFile(
+      'signal-counter.stx',
+      `<script client>\n  const n = derived(() => 42)\n</script>\n<p class="counter">{{ n() }}</p>`,
+    )
+    const out = await render(`<div>@include('signal-counter')</div>`)
+    // Must survive as a runtime marker, not be emptied server-side.
+    expect(out).toMatch(/\{\{\s*n\(\)\s*\}\}/)
+  })
+
+  it('still evaluates <script server> vars in a partial (no over-preservation)', async () => {
+    await createPartialFile(
+      'server-card.stx',
+      `<script server>\n  const who = 'Alice'\n</script>\n<p class="server">{{ who }}</p>`,
+    )
+    const out = await render(`<div>@include('server-card')</div>`)
+    expect(out).toContain('Alice')
+    expect(out).not.toMatch(/\{\{\s*who\s*\}\}/)
+  })
+
+  it('does not over-preserve {{ }} in a signal-free partial', async () => {
+    await createPartialFile('dumb.stx', `<p class="dumb">{{ mystery }}</p>`)
+    const out = await render(`<div>@include('dumb')</div>`)
+    // No signals anywhere → evaluated server-side (undefined → empty), not shipped
+    // to the client as a literal it cannot resolve.
+    expect(out).not.toMatch(/\{\{\s*mystery\s*\}\}/)
+  })
+})


### PR DESCRIPTION
Fixes #1758.

## Problem

`{{ signalCall() }}` reading a signal defined in an `@include` partial's **own `<script client>`** rendered **empty** server-side and never bound on the client. Pages were fine; partials/components were not.

`includes.ts` strips a partial's `<script>` (~L925) before running `processExpressions` on the body. `processExpressions` gates `{{ }}` preservation on `usesSignalsInScript` — but that detects signals by scanning `<script>` blocks, which were just stripped. With no `:if`/`:for`/`:show` in the body to trip the other gate rules, the gate returned false, the `{{ }}` was evaluated server-side (signal undefined → emptied), and the marker was consumed so the re-executed scoped script had nothing to bind.

This was the root cause behind the recent `:text`→`{{ }}` migration regressions (`stacksjs/training#86`, `stacksjs/bench-review#67`), which were worked around app-side by reverting those partials to `:text`.

## Fix

- `processExpressions` gains an optional `{ forceSignals }` — when true, `hasSignals` is forced on.
- `includes.ts` computes `usesSignalsInScript(partialContent)` on the **full** partial content (before the `<script>` strip) and passes it as `forceSignals`.

So a partial with a client signal script preserves `{{ }}` exactly like a top-level page. The preservation is still guarded by the existing `value === undefined && !expressionUsesOnlyContextVars(...)` check, so:
- **server-var partials** (`<script server>` → `{{ who }}`) still evaluate server-side
- **signal-free partials** (`{{ mystery }}`, no script) are **not** over-preserved

## Tests

New `test/includes/signal-partial-mustache.test.ts` (src `processDirectives`, not Bun.build, to avoid the stale-dist realm): signal partial preserves, server partial evaluates to its value, signal-free partial not over-preserved. Full `expressions` + `includes` suites stay green (649 pass on the fix branch; 7755/7755 on the full suite locally).

## Follow-up (not in this PR)

Partials with **no local signals** that rely entirely on a parent's scope (e.g. a dumb confirm dialog reading the parent's `confirmTitle`) are still not handled — they'd need the parent's signal status threaded into include processing. Those stay on `:text` for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)