### PR TITLE
feat: config app.head on already-shelled/SSG pages + dev-server proxy (Nuxt parity)

### DIFF
--- a/packages/bun-plugin/src/serve.ts
+++ b/packages/bun-plugin/src/serve.ts
@@ -1718,6 +1718,43 @@ export async function serve(options: ServeOptions): Promise<void> {
           const url = new URL(req.url)
           let path = url.pathname
 
+          // Dev proxy — forward matching paths to a backend before any routing.
+          // Configured (Vite-style) in stx.config.ts:
+          //   server: { proxy: { '/api': 'http://localhost:8000' } }
+          // or per-rule: { '/api': { target, changeOrigin?, rewrite? } }.
+          // Keys are matched by path prefix; the full path+query is forwarded
+          // (or `rewrite(path)` when given). Lets an stx app talk to a separate
+          // API server in dev without CORS — the parity gap vs Nuxt's
+          // `vite.server.proxy` / `nitro.devProxy`.
+          const proxyRules = (stxConfig as any).server?.proxy as
+            | Record<string, string | { target: string, changeOrigin?: boolean, rewrite?: (p: string) => string }>
+            | undefined
+          if (proxyRules) {
+            for (const [prefix, rule] of Object.entries(proxyRules)) {
+              if (path !== prefix && !path.startsWith(prefix))
+                continue
+              const ruleCfg = typeof rule === 'string' ? { target: rule } : rule
+              const outPath = ruleCfg.rewrite ? ruleCfg.rewrite(path) : path
+              const target = new URL(ruleCfg.target)
+              const outUrl = new URL(outPath + url.search, target)
+              const headers = new Headers(req.headers)
+              if (ruleCfg.changeOrigin !== false)
+                headers.set('host', target.host)
+              try {
+                return await fetch(outUrl, {
+                  method: req.method,
+                  headers,
+                  body: req.body,
+                  redirect: 'manual',
+                  ...(req.body ? { duplex: 'half' } : {}),
+                } as RequestInit)
+              }
+              catch (err) {
+                return new Response(`[stx dev proxy] ${prefix} → ${ruleCfg.target} failed: ${err instanceof Error ? err.message : String(err)}`, { status: 502 })
+              }
+            }
+          }
+
           // i18n: detect + strip locale prefix BEFORE any other routing
           // decision so downstream sees the unprefixed path. Records the
           // resolved locale so the post-render translation pass below uses

--- a/packages/stx/src/document-shell.ts
+++ b/packages/stx/src/document-shell.ts
@@ -163,9 +163,79 @@ export function hasDocumentShell(html: string): boolean {
 }
 
 /**
+ * Inject the config `app.head` tags — script / meta / link / headRaw, but NOT
+ * `title` — into an EXISTING `<head>`.
+ *
+ * `generateDocumentShell` populates config head only when IT builds the shell.
+ * A page whose layout already renders `<html><head>` (the common case, and what
+ * SSG/static builds emit) skips that path, so global config head never lands —
+ * most visibly a site-wide analytics `<script>` (Fathom/Contentsquare/…) that
+ * silently never injects on layout-based or statically-built pages.
+ *
+ * Idempotent: skips a `<script src>`, `<link href>`, meta name/property/charset/
+ * http-equiv, or inline `<script>` content already present in the head, so it's
+ * safe to run even when the layout or `useHead` already emitted the same tag.
+ * `title` is intentionally excluded — the page/layout owns its own title.
+ */
+export function injectConfigHeadTags(html: string, headConfig: AppHeadConfig = {}): string {
+  const headCloseIdx = html.lastIndexOf('</head>')
+  if (headCloseIdx === -1)
+    return html
+
+  const { meta = [], link = [], script = [], headRaw = '' } = headConfig
+  const head = html.slice(0, headCloseIdx)
+  const parts: string[] = []
+
+  for (const m of meta as Record<string, string>[]) {
+    const dedup = m.name
+      ? `name="${m.name}"`
+      : m.property
+        ? `property="${m.property}"`
+        : m.charset != null
+          ? 'charset='
+          : m['http-equiv']
+            ? `http-equiv="${m['http-equiv']}"`
+            : ''
+    if (dedup && head.includes(dedup))
+      continue
+    parts.push(`  <meta ${Object.entries(m).map(([k, v]) => `${k}="${v}"`).join(' ')}>`)
+  }
+
+  for (const l of link as Record<string, string>[]) {
+    if (l.href && head.includes(`href="${l.href}"`))
+      continue
+    parts.push(`  <link ${Object.entries(l).map(([k, v]) => `${k}="${v}"`).join(' ')}>`)
+  }
+
+  for (const s of script as Record<string, any>[]) {
+    if (s.src) {
+      if (head.includes(`src="${s.src}"`))
+        continue
+      parts.push(`  <script ${Object.entries(s).filter(([k]) => k !== 'content').map(([k, v]) => `${k}="${v}"`).join(' ')}></script>`)
+    }
+    else if (s.content) {
+      if (head.includes(s.content))
+        continue
+      parts.push(`  <script>${s.content}</script>`)
+    }
+  }
+
+  if (headRaw && !head.includes(headRaw))
+    parts.push(`  ${headRaw}`)
+
+  if (parts.length === 0)
+    return html
+  return `${html.slice(0, headCloseIdx)}${parts.join('\n')}\n${html.slice(headCloseIdx)}`
+}
+
+/**
  * Wrap HTML in a document shell if it doesn't already have one.
  * This is the main entry point — called at the top level after all
  * directive processing is complete.
+ *
+ * When the html ALREADY has a shell we don't re-wrap (and don't touch its
+ * head here — the caller injects config-only head via `injectConfigHeadTags`,
+ * so runtime `useHead` tags aren't double-emitted).
  */
 export function ensureDocumentShell(
   html: string,

--- a/packages/stx/src/process.ts
+++ b/packages/stx/src/process.ts
@@ -51,7 +51,7 @@ import { processServerBindings } from './server-bindings'
 import { processVueTemplate } from './vue-template'
 import { processDynamicComponents } from './dynamic-components'
 import { processScopedStyles } from './style-scoping'
-import { ensureDocumentShell, injectCloakStyle } from './document-shell'
+import { ensureDocumentShell, hasDocumentShell, injectCloakStyle, injectConfigHeadTags } from './document-shell'
 
 // Extracted modules
 import { hasSignalsSyntax, convertSignalDirectivesToAttributes, convertSignalLoopsToAttributes, preEvalLiteralReactiveIfs, processSignals } from './signal-processing'
@@ -353,7 +353,16 @@ export async function processDirectives(
           ...(runtimeHead.htmlAttrs && { htmlAttrs: { ...(baseHeadConfig.htmlAttrs || {}), ...runtimeHead.htmlAttrs } }),
           ...(runtimeHead.bodyAttrs && { bodyAttrs: { ...(baseHeadConfig.bodyAttrs || {}), ...runtimeHead.bodyAttrs } }),
         }
+        // A page/layout that already rendered its own <html><head> (the common
+        // case, and what SSG/static builds emit) makes ensureDocumentShell a
+        // no-op, so config `app.head` (script/meta/link/headRaw) never got into
+        // the head — most visibly a site-wide analytics <script>. Inject the
+        // CONFIG head (not the merged runtime head — renderHead below handles
+        // useHead) into the existing head, idempotently. See stacksjs/stx#1765.
+        const alreadyShelled = hasDocumentShell(result)
         result = ensureDocumentShell(result, headConfig)
+        if (alreadyShelled)
+          result = injectConfigHeadTags(result, baseHeadConfig)
 
         // Inject layout meta tag for SPA layout-change detection
         const layoutComment = result.match(/<!-- stx-layout: ([^ ]+) -->/)

--- a/packages/stx/test/shell/config-head-existing-shell.test.ts
+++ b/packages/stx/test/shell/config-head-existing-shell.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression: config `app.head` must land on pages that ALREADY render their
+ * own <html><head> (layout-based / SSG static builds) — not just when stx
+ * builds the shell. Otherwise a site-wide analytics <script> (Fathom /
+ * Contentsquare / ts-analytics) silently never injects on static builds.
+ * See stacksjs/stx#1765.
+ */
+import { describe, expect, it } from 'bun:test'
+import { injectConfigHeadTags } from '../../src/document-shell'
+
+const HEAD = (inner = '') => `<!doctype html><html><head><title>Page</title>${inner}</head><body><h1>Hi</h1></body></html>`
+const count = (s: string, needle: string): number => s.split(needle).length - 1
+
+describe('injectConfigHeadTags (config app.head into an existing shell)', () => {
+  it('injects config app.head.script into an existing <head>', () => {
+    const out = injectConfigHeadTags(HEAD(), { script: [{ src: 'https://cs.example.com/uxa.js', defer: true }] } as any)
+    expect(out).toContain('src="https://cs.example.com/uxa.js"')
+    expect(out).toContain('defer="true"')
+    // before </head>
+    expect(out.indexOf('cs.example.com')).toBeLessThan(out.indexOf('</head>'))
+  })
+
+  it('injects config meta and link', () => {
+    const out = injectConfigHeadTags(HEAD(), { meta: [{ name: 'description', content: 'D' }], link: [{ rel: 'icon', href: '/favicon.ico' }] } as any)
+    expect(out).toContain('name="description"')
+    expect(out).toContain('href="/favicon.ico"')
+  })
+
+  it('is idempotent — never duplicates a script src / link href / meta already present', () => {
+    const already = HEAD('<script src="https://cs.example.com/uxa.js" defer></script><meta charset="utf-8">')
+    const out = injectConfigHeadTags(already, {
+      script: [{ src: 'https://cs.example.com/uxa.js', defer: true }],
+      meta: [{ charset: 'utf-8' }, { name: 'description', content: 'D' }],
+    } as any)
+    expect(count(out, 'cs.example.com/uxa.js')).toBe(1)
+    expect(count(out, 'charset=')).toBe(1)
+    expect(out).toContain('name="description"') // the new one IS added
+  })
+
+  it('never injects a config title (page/layout owns its title)', () => {
+    const out = injectConfigHeadTags(HEAD(), { title: 'Config Title', script: [{ src: '/a.js' }] } as any)
+    expect(out).not.toContain('Config Title')
+    expect(count(out, '<title>')).toBe(1)
+  })
+
+  it('injects inline <script> content, deduped', () => {
+    const out = injectConfigHeadTags(HEAD(), { script: [{ content: 'window.X=1' }] } as any)
+    expect(out).toContain('<script>window.X=1</script>')
+    expect(count(injectConfigHeadTags(out, { script: [{ content: 'window.X=1' }] } as any), 'window.X=1')).toBe(1)
+  })
+
+  it('no-ops when there is no </head> (SPA fragment)', () => {
+    const frag = '<main>hi</main>'
+    expect(injectConfigHeadTags(frag, { script: [{ src: '/a.js' }] } as any)).toBe(frag)
+  })
+})


### PR DESCRIPTION
Two Nuxt-config parity gaps, surfaced by mapping a real Nuxt app (`app.head.script` for Contentsquare/Fathom + `vite.server.proxy`) onto stx.

## 1. `app.head` now injects on already-shelled / SSG pages
`ensureDocumentShell` only populated config `app.head` when **it** built the shell. A page whose layout already renders `<html><head>` — the common case, and what SSG/static builds emit — skipped that, so a site-wide analytics `<script>` (Fathom / Contentsquare / `ts-analytics`) **silently never injected on static builds**. (This is the gap that made `tsAnalytics()` need a companion `tsAnalyticsTag()`.)

New `injectConfigHeadTags()` injects the **config** head (script/meta/link/headRaw — *not* the merged runtime head; `renderHead` still owns `useHead`) into the existing `<head>`, **idempotently** — deduped by script `src`, link `href`, meta `name`/`property`/`charset`/`http-equiv`, and inline content. `title` is left to the page.

Verified: fragment still works; full-doc pages now get the script; exactly one tag (no double); layout's own `charset` not duplicated; re-running is a no-op.

## 2. dev-server `server.proxy` (Vite-style)
Forward matching paths to a backend before routing, so an stx app can hit a separate API in dev without CORS:
```ts
// config/stx.ts
server: { proxy: { '/api': 'http://localhost:8000' } }
// or per-rule:
server: { proxy: { '/api': { target: 'http://localhost:8000', changeOrigin: true, rewrite: p => p.replace('/api','') } } }
```
Keys match by path prefix; full path+query forwarded (or `rewrite(path)`), `changeOrigin` sets the Host header. Closes the gap vs Nuxt's `vite.server.proxy` / `nitro.devProxy`. (HTTP only for now — WS proxying is a follow-up.)

Verified end-to-end against a live backend: GET path+query, POST body, changeOrigin, rewrite, and non-matching pass-through.

## Tests
`test/shell/config-head-existing-shell.test.ts` (6 cases). Full suite green (9465 pass).