### PR TITLE
fix(client-script): bind template names shadowed by inlined imports (#1767)

### DIFF
--- a/packages/stx/src/client-script-bundler.ts
+++ b/packages/stx/src/client-script-bundler.ts
@@ -338,12 +338,42 @@ export async function bundleClientScript(
       break
     }
 
+    // Capture Bun's export-rename map BEFORE stripping (stacksjs/stx#1767).
+    // When an inlined import shares a top-level name with a component-declared
+    // const, Bun.build keeps the import under the bare name and RENAMES the
+    // local (`foo` -> `foo2`); the catch-all export we added above then comes
+    // back as `export { foo2 as foo }`. That `as` clause is the only record of
+    // the rename. If we strip it blindly, the scope registrar re-harvests the
+    // bare `foo` — now the raw import — and binds the template to the wrong
+    // value. So collect [originalName, renamedBinding] pairs here and re-expose
+    // them below, letting the registrar bind the original name to the correct
+    // (renamed) identifier without touching the import the local closes over.
+    const renamePairs: Array<[string, string]> = []
+    for (const exp of bundled.matchAll(/^\s*export\s*\{([^}]*)\}\s*;?\s*$/gm)) {
+      for (const spec of exp[1].split(',')) {
+        const asMatch = spec.trim().match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/)
+        if (asMatch && asMatch[1] !== asMatch[2])
+          renamePairs.push([asMatch[2], asMatch[1]]) // [exported/original name, renamed local binding]
+      }
+    }
+
     // Strip ESM export artifacts from the output
     // Bun.build with format: 'esm' may add `export { ... }` at the end
     bundled = bundled
       .replace(/^\s*export\s*\{[^}]*\}\s*;?\s*$/gm, '')
       .replace(/^\s*export\s+default\s+.*$/gm, '')
       .trim()
+
+    // Re-expose renamed component declarations under their ORIGINAL names as a
+    // plain map (originalName -> renamed binding). The scope registrar merges
+    // this so the template binds to the component's declaration, not the
+    // shadowing import. We do NOT reassign the bare name (`var foo = foo2`):
+    // the renamed local's closure still reads the import under `foo`, so
+    // clobbering it would break the binding it depends on. See #1767.
+    if (renamePairs.length > 0) {
+      const entries = renamePairs.map(([orig, id]) => `${JSON.stringify(orig)}: ${id}`).join(', ')
+      bundled += `\nvar __stxScopeRenames = { ${entries} };`
+    }
 
     // Strip any remaining external import statements (stx, @stores etc.)
     // These will be handled by transformAutoImports and transformStoreImports

--- a/packages/stx/src/includes.ts
+++ b/packages/stx/src/includes.ts
@@ -298,6 +298,11 @@ function transformSignalScript(scriptContent: string, scopeId: string): string {
   if (!window.stx._scopes) window.stx._scopes = {};
   var __scopeRegistration = { __destroyCallbacks: __destroyHooks };
 ${scopeAssign}
+  // #1767: when the bundler renamed a component const that collided with an
+  // inlined import (foo -> foo2), rebind the ORIGINAL template name to the
+  // renamed declaration so it resolves to the component's value, not the
+  // shadowing import. __stxScopeRenames is emitted by bundleClientScript.
+  try { if (typeof __stxScopeRenames !== 'undefined' && __stxScopeRenames) { for (var __stxRK in __stxScopeRenames) __scopeRegistration[__stxRK] = __stxScopeRenames[__stxRK]; } } catch (e) { /* no renames */ }
   window.stx._scopes['${scopeId}'] = __scopeRegistration;
 `
   // Set __STX_CURRENT_ELEMENT__ to this scope's root element while the body runs,

--- a/packages/stx/src/signals.ts
+++ b/packages/stx/src/signals.ts
@@ -1859,7 +1859,10 @@ else if (name === '@text' || name === ':text' || name === 'x-text') {
       }
 else if (name === '@html' || name === ':html' || name === 'x-html') {
         effect(() => {
-          el.innerHTML = evalAttrExpr(value);
+          // Coerce null/undefined to '' so a missing/unresolved binding renders
+          // nothing rather than the literal string "undefined" (#1767).
+          var __html = evalAttrExpr(value);
+          el.innerHTML = (__html == null) ? '' : __html;
         });
         el.removeAttribute(name);
       }

--- a/packages/stx/test/client-script-bundler/import-shadow-collision.test.ts
+++ b/packages/stx/test/client-script-bundler/import-shadow-collision.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the import/local name-shadow collision (stacksjs/stx#1767).
+ *
+ * When a `<script client>` imports from a module AND declares a top-level
+ * `const` whose name equals a top-level export of that module, `Bun.build`
+ * inlines the import under the bare name and RENAMES the component's local
+ * (`items` -> `items2`). The catch-all export the bundler adds to defeat
+ * tree-shaking then comes back as `export { items2 as items }`. Pre-fix,
+ * that `as` mapping was stripped and discarded, so scope registration
+ * re-harvested the bare `items` (now the raw import) and bound the template
+ * to the wrong value — a silent misregistration.
+ *
+ * Fix: capture the rename map before stripping and re-expose it as
+ * `var __stxScopeRenames = { "items": items2 }` so the scope registrar can
+ * bind the ORIGINAL name to the renamed (correct) binding.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { bundleClientScript } from '../../src/client-script-bundler'
+
+const TMP = path.join(import.meta.dir, 'temp-shadow')
+
+describe('client-script-bundler: import/local name shadow (#1767)', () => {
+  let projectRoot: string
+  let templatePath: string
+
+  beforeEach(async () => {
+    projectRoot = path.join(TMP, `project-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    templatePath = path.join(projectRoot, 'Widget.stx')
+    await fs.promises.mkdir(projectRoot, { recursive: true })
+    await Bun.write(path.join(projectRoot, 'data.ts'), `export const items = [{ id: 1, label: 'raw' }]\n`)
+  })
+
+  afterEach(async () => {
+    if (fs.existsSync(TMP))
+      await fs.promises.rm(TMP, { recursive: true, force: true })
+  })
+
+  it('re-exposes a rename map when a local const shadows an inlined import export', async () => {
+    // The component aliases the import (`allItems`) yet still declares a local
+    // `const items` that collides with data.ts's `export const items`.
+    const script = `import { items as allItems } from './data'\nconst items = derived(() => allItems.map(x => ({ ...x, extra: 'computed' })))`
+    const out = await bundleClientScript(script, templatePath, { projectRoot })
+
+    // Bun renamed the component's local:
+    expect(out).toMatch(/\bitems2\b/)
+    // ...and the fix re-exposes ORIGINAL name -> renamed binding, so the
+    // registrar binds the template's `items` to the derived, not the import:
+    expect(out).toMatch(/__stxScopeRenames\s*=\s*\{\s*"items":\s*items2\s*\}/)
+  })
+
+  it('emits no rename map when there is no name collision', async () => {
+    const script = `import { items as allItems } from './data'\nconst list = derived(() => allItems.map(x => x))`
+    const out = await bundleClientScript(script, templatePath, { projectRoot })
+    expect(out).not.toContain('__stxScopeRenames')
+  })
+})


### PR DESCRIPTION
Fixes #1767.

## The bug

A component `<script client>` that **imports from a module** *and* declares a top-level `const` whose name equals a **top-level export of that module** silently loses its binding. `bundleClientScript`'s `Bun.build` inlines the import under the bare name and renames the component's local (`foo` → `foo2`). The catch-all `export { foo }` the bundler already adds (to defeat tree-shaking) comes back as `export { foo2 as foo }` — the only record of the rename — and line 343's blind strip discards it. Scope registration then re-harvests the bare `foo` (now the raw import) and binds the template to the wrong value. Aliasing the import (`import { foo as bar }`) doesn't help.

Symptom in the wild: a `:for` over the "derived" iterated the raw import, and `x-html="it.missing"` rendered the literal string `undefined` (clipped to "defin" in a small avatar — very confusing to debug).

## Minimal repro

`data.ts`
```ts
export const items = [{ id: 1, label: 'raw' }]
```
`Widget.stx`
```html
<script client>
  import { items as allItems } from './data'
  const items = derived(() => allItems.map(x => ({ ...x, extra: 'computed' })))
</script>
<div :for="it in items">{{ it.extra }}</div>
```
Expected `it.extra === 'computed'`; actual `undefined` (binds to the raw import). The emitted bundle shows `var items2 = derived(...)` while the template still binds bare `items`.

## The fix

- **`bundleClientScript`** — capture the `X as Y` rename map before stripping the export, and re-expose it as `var __stxScopeRenames = { "Y": X }` (original name → renamed binding). It deliberately does **not** reassign the bare name (`var foo = foo2`): the renamed local's closure still reads the import under `foo`, so clobbering it would break the very binding it depends on. Emitted only when a rename actually happened.
- **`transformSignalScript`** — merge `__stxScopeRenames` into `__scopeRegistration` after the normal harvest, so the template's original name resolves to the component's declaration, not the shadowing import.
- **`x-html`** — coerce `null`/`undefined` to `''` before `innerHTML =`, so a missing/unresolved binding renders nothing instead of the literal string `undefined`.

## Verification

- New regression test: `test/client-script-bundler/import-shadow-collision.test.ts`.
- Full suite green — **7795 pass**, no regressions from this change (the lone failure in a full run is a pre-existing flaky `route-middleware` throttling test that passes in isolation on both this branch and `main`).
- End-to-end: compiled a real `@include` and evaluated the emitted scope registration — the original name now binds to the derived (`extra: "computed"`), not the raw import.

## Scope / follow-up

This wires the fix through the per-component scope path (`includes.ts transformSignalScript`) — the reproduced case. The page-level merged-script path (`signal-processing.ts`, `return { ...mergedExports }`) shares the same `extractExports`-on-bundled-code pattern and would benefit from consuming `__stxScopeRenames` too; left out here to keep the change focused and low-risk (multiple merged scripts would need per-script map names). Happy to extend if preferred.
