### PR TITLE
feat(dx): dev-mode warning for unbalanced template tags (#1769)

### DIFF
--- a/packages/stx/src/includes.ts
+++ b/packages/stx/src/includes.ts
@@ -69,6 +69,7 @@
 import type { StxOptions } from './types'
 import path from 'node:path'
 import { processConditionals } from './conditionals'
+import { isProduction, isTest } from './env'
 import { processExpressions, usesSignalsInScript } from './expressions'
 import { LRUCache } from './performance-utils'
 import { createSafeFunction, isExpressionSafe, safeEvaluate, safeEvaluateObject } from './safe-evaluator'
@@ -878,6 +879,20 @@ catch (error: unknown) {
       if (partialContent && partialContent.includes('@stream')) {
         const { processStreamDirectives } = await import('./streaming')
         partialContent = processStreamDirectives(partialContent, context)
+      }
+
+      // #1769: dev-mode tag-balance heads-up on the RAW partial, before SFC
+      // extraction / directive processing auto-closes anything. A dropped
+      // </div> silently re-parents following siblings and blanks the page with
+      // no error at any layer; a coarse per-tag open/close count catches it.
+      // On by default in development; opt-in via `debug` elsewhere; off in prod
+      // + the test runner. Pre-gated so the dynamic import is dev-only.
+      if (partialContent && (options.debug || (!isProduction() && !isTest()))) {
+        try {
+          const { warnUnbalancedTags } = await import('./template-tag-balance')
+          warnUnbalancedTags(partialContent, includeFilePath)
+        }
+        catch {}
       }
 
       // SFC Support: Extract <template>, <script>, and <style> sections

--- a/packages/stx/src/process.ts
+++ b/packages/stx/src/process.ts
@@ -60,6 +60,8 @@ import { processInlineAssets } from './inline-assets'
 import { addCloakToConditionalDirectives, addCloakToUnresolvedExpressions, processJsonDirective, processMemoDirective, processOnceDirective, processRefAttributes } from './misc-directives'
 import { validateClientScript } from './script-validation'
 import { safeEvaluate } from './safe-evaluator'
+import { isProduction, isTest } from './env'
+import { warnUnbalancedTags } from './template-tag-balance'
 import { deriveLayoutGroup } from 'stx-router/layout-metadata'
 
 // Re-export public API from extracted modules (preserves backwards compatibility)
@@ -297,6 +299,15 @@ export async function processDirectives(
   // across separate processDirectives calls (e.g. between test runs or server requests)
   if (!context.__onceStore) {
     context.__onceStore = new Set<string>()
+  }
+
+  // #1769: dev-mode tag-balance heads-up for top-level views/layouts, on the
+  // RAW template before any processing auto-closes tags. @include'd partials
+  // are checked separately in the include pipeline. On by default in
+  // development; opt-in via `debug` elsewhere; off in prod + the test runner.
+  // Deduped + best-effort.
+  if ((options.debug || (!isProduction() && !isTest())) && filePath && filePath.endsWith('.stx')) {
+    warnUnbalancedTags(template, filePath)
   }
 
   try {

--- a/packages/stx/src/template-tag-balance.ts
+++ b/packages/stx/src/template-tag-balance.ts
@@ -1,0 +1,146 @@
+/**
+ * Dev-mode template tag-balance check (stacksjs/stx#1769).
+ *
+ * A single dropped closing tag (e.g. a missing `</div>`) is silently
+ * auto-closed by the HTML parser at EOF, re-parenting every following sibling
+ * INSIDE the unclosed element. Those siblings then inherit the element's
+ * `x-show`/`display:none` state and render blank — with zero diagnostics at any
+ * layer (the server 200s, hydration succeeds, no console output). The failure
+ * is purely structural and only visible by eye.
+ *
+ * This does a coarse, void- and optional-close-aware open/close COUNT per tag
+ * name and reports any mismatch. It intentionally does not attempt a full HTML
+ * parse: the goal is a cheap, high-signal dev heads-up, not a validator.
+ */
+
+// Void elements never take a closing tag — excluded from counting entirely.
+const VOID_TAGS: ReadonlySet<string> = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+  'link', 'meta', 'param', 'source', 'track', 'wbr',
+])
+
+// Elements whose end tag may be legally omitted (HTML spec). A count mismatch
+// on these is usually idiomatic (`<li>`/`<td>`/`<p>` without a close), so we
+// never warn on them — this is what keeps the check false-positive-free.
+const OPTIONAL_CLOSE_TAGS: ReadonlySet<string> = new Set([
+  'html', 'head', 'body', 'p', 'li', 'dt', 'dd', 'rt', 'rp',
+  'option', 'optgroup', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
+  'colgroup', 'caption',
+])
+
+export interface TagBalanceIssue {
+  /** Tag name as written (case preserved, so `<Icon>`/`</Icon>` match). */
+  tag: string
+  opened: number
+  closed: number
+  /** 1-based line of the first opening tag of this name (best-effort). */
+  firstOpenLine: number
+}
+
+/** Replace every non-newline char with a space so line/column numbers of the
+ *  surviving text stay accurate after a region is neutralised. */
+function blankKeepingLines(s: string): string {
+  return s.replace(/[^\n]/g, ' ')
+}
+
+/**
+ * Return the set of tag names whose opening/closing counts don't balance.
+ * Pure and side-effect free.
+ */
+export function findUnbalancedTags(template: string): TagBalanceIssue[] {
+  // Neutralise regions where a `<`/`>` is not markup: scripts, styles, HTML
+  // comments, stx interpolations, and quoted attribute values (so a literal
+  // `>` inside an attribute value can't prematurely "close" a tag).
+  const stripped = template
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, blankKeepingLines)
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, blankKeepingLines)
+    .replace(/<!--[\s\S]*?-->/g, blankKeepingLines)
+    .replace(/\{\{\{[\s\S]*?\}\}\}/g, blankKeepingLines)
+    .replace(/\{\{[\s\S]*?\}\}/g, blankKeepingLines)
+    .replace(/\{!![\s\S]*?!!\}/g, blankKeepingLines)
+    .replace(/"[^"]*"/g, blankKeepingLines)
+    .replace(/'[^']*'/g, blankKeepingLines)
+
+  interface OpenInfo { count: number, firstLine: number }
+  const opens = new Map<string, OpenInfo>()
+  const closes = new Map<string, number>()
+
+  const tagRe = /<(\/?)([A-Za-z][\w-]*)\b[^>]*?(\/?)>/g
+  let m: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((m = tagRe.exec(stripped)) !== null) {
+    const isClose = m[1] === '/'
+    const name = m[2]
+    const selfClose = m[3] === '/'
+    if (VOID_TAGS.has(name.toLowerCase()))
+      continue
+    if (selfClose)
+      continue
+    if (isClose) {
+      closes.set(name, (closes.get(name) ?? 0) + 1)
+    }
+    else {
+      const existing = opens.get(name)
+      if (existing) {
+        existing.count++
+      }
+      else {
+        const line = stripped.slice(0, m.index).split('\n').length
+        opens.set(name, { count: 1, firstLine: line })
+      }
+    }
+  }
+
+  const issues: TagBalanceIssue[] = []
+  for (const name of new Set([...opens.keys(), ...closes.keys()])) {
+    if (OPTIONAL_CLOSE_TAGS.has(name.toLowerCase()))
+      continue
+    const opened = opens.get(name)?.count ?? 0
+    const closed = closes.get(name) ?? 0
+    if (opened !== closed)
+      issues.push({ tag: name, opened, closed, firstOpenLine: opens.get(name)?.firstLine ?? 0 })
+  }
+  return issues
+}
+
+// Dedupe key = filePath + template length, so a given broken file warns once
+// (not once per request or per @include site); an edit that changes the file's
+// length re-arms the warning. Dev-only + bounded to actually-broken files.
+const warnedKeys = new Set<string>()
+
+/**
+ * Dev-mode warning: log any tag-balance issues for a template. Best-effort — a
+ * diagnostic must never throw and break the build.
+ */
+export function warnUnbalancedTags(template: string, filePath: string): void {
+  let issues: TagBalanceIssue[]
+  try {
+    issues = findUnbalancedTags(template)
+  }
+  catch {
+    return
+  }
+  if (issues.length === 0)
+    return
+
+  const dedupeKey = `${filePath}:${template.length}`
+  if (warnedKeys.has(dedupeKey))
+    return
+  warnedKeys.add(dedupeKey)
+
+  const label = filePath ? (filePath.split(/[/\\]/).pop() || filePath) : 'template'
+  for (const { tag, opened, closed, firstOpenLine } of issues) {
+    if (opened > closed) {
+      const where = firstOpenLine ? ` (first opened at line ${firstOpenLine})` : ''
+      console.warn(
+        `[stx] ${label}: <${tag}> ${opened} opened, ${closed} closed — an unclosed <${tag}>${where} `
+        + `may swallow the content that follows it.`,
+      )
+    }
+    else {
+      console.warn(
+        `[stx] ${label}: <${tag}> ${opened} opened, ${closed} closed — ${closed - opened} stray </${tag}>.`,
+      )
+    }
+  }
+}

--- a/packages/stx/test/template-tag-balance.test.ts
+++ b/packages/stx/test/template-tag-balance.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the dev-mode template tag-balance check (stacksjs/stx#1769).
+ *
+ * A dropped closing tag (e.g. a missing </div>) is auto-closed at EOF and
+ * silently re-parents the following siblings inside the unclosed element,
+ * blanking the page with no error at any layer. These verify the coarse
+ * open/close count catches that while staying false-positive-free on void
+ * elements, optional-close elements, self-closing components, and tags that
+ * appear inside scripts/styles/comments/interpolations/attributes.
+ */
+import { describe, expect, it, spyOn } from 'bun:test'
+import { processDirectives } from '../src/process'
+import { findUnbalancedTags, warnUnbalancedTags } from '../src/template-tag-balance'
+
+describe('findUnbalancedTags (#1769)', () => {
+  it('flags a dropped closing tag', () => {
+    const issues = findUnbalancedTags(`<div><div x-show="a"><p>A</p><div x-show="b"><p>B</p></div></div>`)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].tag).toBe('div')
+    expect(issues[0].opened).toBe(3)
+    expect(issues[0].closed).toBe(2)
+    expect(issues[0].firstOpenLine).toBe(1)
+  })
+
+  it('is silent for balanced markup', () => {
+    expect(findUnbalancedTags(`<div><section><p>hi</p></section></div>`)).toEqual([])
+  })
+
+  it('ignores void elements', () => {
+    expect(findUnbalancedTags(`<div><br><img src="x"><input></div>`)).toEqual([])
+  })
+
+  it('ignores self-closing components', () => {
+    expect(findUnbalancedTags(`<div><Icon name="x" /><Foo-Bar /></div>`)).toEqual([])
+  })
+
+  it('ignores optional-close elements (li / td / p)', () => {
+    expect(findUnbalancedTags(`<ul><li>a<li>b</ul><table><tr><td>x<td>y</table>`)).toEqual([])
+  })
+
+  it('ignores tags inside scripts, styles, and comments', () => {
+    expect(findUnbalancedTags(`<div><script>if(a<b){}</script><style>.x>.y{}</style><!-- <div> --></div>`)).toEqual([])
+  })
+
+  it('ignores > inside attributes and {{ }} interpolations', () => {
+    expect(findUnbalancedTags(`<div title="a > b">{{ a > b }}<span>x</span></div>`)).toEqual([])
+  })
+
+  it('flags an unbalanced component tag (case preserved)', () => {
+    const issues = findUnbalancedTags(`<div><StxLink to="/a"><span>x</span></div>`)
+    expect(issues.some(i => i.tag === 'StxLink' && i.opened === 1 && i.closed === 0)).toBe(true)
+  })
+
+  it('flags a stray closing tag', () => {
+    const issues = findUnbalancedTags(`<div><span>x</span></div></div>`)
+    expect(issues[0].tag).toBe('div')
+    expect(issues[0].closed).toBeGreaterThan(issues[0].opened)
+  })
+
+  it('keeps accurate line numbers past neutralised regions', () => {
+    const tpl = `<div>\n<script>\n<div>\n</script>\n<section>\n<div>\n</div>\n<span>x</span>`
+    const issues = findUnbalancedTags(tpl)
+    // the <div> inside <script> is ignored; the outer <div> on line 1 is unclosed
+    expect(issues.find(i => i.tag === 'div')?.firstOpenLine).toBe(1)
+  })
+})
+
+describe('warnUnbalancedTags (#1769)', () => {
+  it('warns with a helpful, file-labelled message', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    warnUnbalancedTags(`<div><div x-show="a"><p>A</p></div>`, '/x/SettingsTab.stx')
+    const msg = warn.mock.calls.map(c => c.join(' ')).join('\n')
+    expect(msg).toContain('SettingsTab.stx')
+    expect(msg).toContain('<div>')
+    expect(msg).toMatch(/opened/)
+    warn.mockRestore()
+  })
+
+  it('does not throw and stays silent on balanced input', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() => warnUnbalancedTags(`<div><p>ok</p></div>`, '/x/Ok.stx')).not.toThrow()
+    expect(warn.mock.calls.some(c => c.join(' ').includes('opened'))).toBe(false)
+    warn.mockRestore()
+  })
+})
+
+describe('processDirectives tag-balance integration (#1769)', () => {
+  it('warns in debug mode when a top-level template drops a </div>', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    const tpl = `<div><div x-show="a"><p>A</p><div x-show="b"><p>B</p></div></div>`
+    await processDirectives(tpl, { props: {} }, '/proj/TabPanelWidget.stx', { debug: true } as any, new Set())
+    const balMsg = warn.mock.calls.map(c => c.join(' ')).filter(l => l.includes('opened')).join('\n')
+    expect(balMsg).toContain('TabPanelWidget.stx')
+    warn.mockRestore()
+  })
+
+  it('does not emit a balance warning when debug is off', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+    const tpl = `<section><div x-show="a"><p>A</p><div><p>B</p></div></section>`
+    await processDirectives(tpl, { props: {} }, '/proj/NoDebugWidget.stx', { debug: false } as any, new Set())
+    const balMsg = warn.mock.calls.map(c => c.join(' ')).filter(l => l.includes('opened')).join('\n')
+    expect(balMsg).toBe('')
+    warn.mockRestore()
+  })
+})


### PR DESCRIPTION
Closes #1769.

## The problem

A single dropped closing tag (a missing `</div>`) is silently auto-closed by the HTML parser at EOF, re-parenting every following sibling **inside** the unclosed element. Those siblings inherit its `x-show`/`display:none` and render blank — with **zero diagnostics at any layer**: the server 200s, hydration succeeds, no console output. It's only visible by eye (or by walking `getComputedStyle` up the ancestor chain).

## The fix

A coarse, void- and optional-close-aware **open/close count per tag name**, run at template-parse time and warning on any mismatch:

```
[stx] SettingsTab.stx: <div> 47 opened, 46 closed — an unclosed <div> (first opened at line 771) may swallow the content that follows it.
```

- **`template-tag-balance.ts`** — a small module: pure `findUnbalancedTags()` (fully unit-tested) + `warnUnbalancedTags()`. It's deliberately a *count*, not a parse — the goal is a cheap, high-signal heads-up.
- **Where it runs:** `processDirectives` on the raw template of views/layouts, and the include pipeline on each `@include`d partial's raw content (the issue's exact case — a tab component). Both check the RAW source *before* any processing auto-closes tags.
- **When it runs:** on by default in development; opt-in via `debug` elsewhere (`options.debug || (!isProduction() && !isTest())`). Off in the production build and under the test runner, so it never adds noise to CI or the shipped bundle. Deduped per file (warns once; re-arms on edit).

## False-positive-free by design

It ignores, and there are tests for each: void elements (`<br>`, `<img>`, …), optional-close elements (`<li>`, `<td>`, `<p>`, …), self-closing components (`<Icon />`), and any `<`/`>` inside `<script>`/`<style>`/comments/`{{ }}` interpolations/quoted attribute values. Component tags (`<StxLink>…</StxLink>`) are checked case-preserved, so an unbalanced component is caught too.

## Verification

- 14 new tests (`test/template-tag-balance.test.ts`): the pure counter across all the edge cases above, `warnUnbalancedTags` message/dedupe, and a `processDirectives` integration test confirming the hook fires in dev and stays quiet otherwise.
- Full suite green: **7810 pass, 0 fail**.
- Manually confirmed: fires in `NODE_ENV=development` with no `debug` flag; silent in `NODE_ENV=production`.

## Notes for review

- The default-on-in-dev gate is the deliberate call (the request was to catch this *during* development, and `debug` defaults to `false`). Easy to flip to `debug`-only if you'd rather it be opt-in.
- It reports every imbalanced tag name (unclosed *and* stray-close), keyed by the first opening line.
