### PR TITLE
fix(conditionals): don't match directive tokens inside HTML tags

### DIFF
--- a/packages/stx/src/parser/directive-parser.ts
+++ b/packages/stx/src/parser/directive-parser.ts
@@ -88,6 +88,27 @@ export function extractParenthesizedExpressionDetailed(source: string, startPos:
 // =============================================================================
 
 /**
+ * Whether `pos` in `source` falls INSIDE an HTML tag (`<...>`) — i.e. the nearest
+ * angle bracket looking backwards is an unclosed `<`.
+ *
+ * Directive tokens (`@if`/`@elseif`/`@else`/`@endif`) only ever occur in text
+ * content, never inside a tag. The reactive-signal pass, however, rewrites a
+ * NESTED reactive conditional into HTML-attribute markers BEFORE this server pass
+ * runs — e.g. `@if (isPro())A@else B@endif` becomes
+ * `<template @if="isPro()">A</template><template @else>B</template>`. Without this
+ * guard the branch scanner matches that `@else` ATTRIBUTE as the enclosing server
+ * `@if`'s top-level `@else`, mismatching branch/`@endif` boundaries and corrupting
+ * the rest of the template. Skipping tag-interior tokens keeps the two passes from
+ * disagreeing on what is a directive.
+ */
+export function isInsideTag(source: string, pos: number): boolean {
+  const lastOpen = source.lastIndexOf('<', pos)
+  if (lastOpen === -1)
+    return false
+  return lastOpen > source.lastIndexOf('>', pos)
+}
+
+/**
  * Find the matching end tag for a directive, handling nested instances
  *
  * @param source - The source string to search in
@@ -184,6 +205,15 @@ export function parseConditionalBlock(source: string, startPos: number): ParsedC
     if (atIdx === -1) break
     currentPos = atIdx
     const remaining = fullContent.substring(atIdx)
+
+    // Ignore directive-looking tokens that are actually HTML attributes (inside a
+    // `<...>` tag), e.g. the `<template @else>` markers the reactive-signal pass
+    // emits for a nested reactive conditional. Matching them here would mismatch
+    // this block's branch/@endif boundaries. See isInsideTag().
+    if (isInsideTag(fullContent, atIdx)) {
+      currentPos++
+      continue
+    }
 
     // Track nested @if depth
     if (/^@if\s*\(/.test(remaining)) {

--- a/packages/stx/test/directives/conditionals.test.ts
+++ b/packages/stx/test/directives/conditionals.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import { processConditionals, processAuthDirectives, processEnvDirective, processIssetEmptyDirectives, processSwitchStatements } from '../../src/conditionals'
+import { convertSignalDirectivesToAttributes } from '../../src/signal-processing'
 
 describe('Conditionals Comprehensive', () => {
   const filePath = 'test.stx'
@@ -1561,5 +1562,64 @@ describe('Conditionals Comprehensive', () => {
       const result = processSwitchStatements('@switch(val)@case("a")first@break@case("a")second@break@endswitch', { val: 'a' }, filePath)
       expect(result.trim()).toBe('first')
     })
+  })
+})
+
+// Regression: a NESTED reactive @if/@else lives inside a server @if. The signal
+// pass rewrites the inner reactive conditional into `<template @else>` HTML-
+// attribute markers BEFORE processConditionals runs; the server branch scanner
+// must NOT mistake that `@else` attribute for the enclosing @if's top-level
+// @else, or it mismatches @endif boundaries and corrupts the template.
+describe('@if — nested reactive conditional inside a server @if', () => {
+  const filePath = 'test.stx'
+  // Mirrors the app case: outer `@if (ownsActive)` (server) wrapping an inner
+  // `@if (isPro())…@else…@endif` (reactive signal). isPro is a client state().
+  const twoPass = (ownsActive: boolean) => {
+    const tpl = `<script>const isPro = state(false)</script>`
+      + `<div>@if (ownsActive)BEFORE@if (isPro())PRO@else FREE@endif AFTER@else LOCKED@endif</div>`
+    return processConditionals(convertSignalDirectivesToAttributes(tpl, { ownsActive }), { ownsActive }, filePath)
+  }
+
+  it('keeps the full true-branch (incl. content after the inner block) when the outer @if is true', () => {
+    const out = twoPass(true)
+    expect(out).toContain('BEFORE')
+    expect(out).toContain('AFTER')
+    // the inner reactive markers survive intact for the later client pass
+    expect(out).toContain('<template @if="isPro()">PRO</template>')
+    expect(out).toContain('<template @else>FREE</template>')
+    // the OUTER else-branch is not shown, and nothing is truncated mid-tag
+    expect(out).not.toContain('LOCKED')
+    expect(out).not.toMatch(/<template\s*<\/div>/)
+  })
+
+  it('shows the outer else-branch (and no reactive markers) when the outer @if is false', () => {
+    const out = twoPass(false)
+    expect(out).toContain('LOCKED')
+    expect(out).not.toContain('<template')
+    expect(out).not.toContain('BEFORE')
+    expect(out).not.toContain('AFTER')
+  })
+
+  it('handles an inner reactive @elseif chain without corrupting the outer block', () => {
+    const tpl = `<script>const tier = state(0)</script>`
+      + `<div>@if (ownsActive)A@if (tier() === 1)ONE@elseif (tier() === 2)TWO@else NONE@endif B@endif</div>`
+    const out = processConditionals(convertSignalDirectivesToAttributes(tpl, { ownsActive: true }), { ownsActive: true }, filePath)
+    expect(out).toContain('A')
+    expect(out).toContain('B')
+    expect(out).toContain('<template @if="tier() === 1">ONE</template>')
+  })
+
+  it('still expands a normal nested SERVER @if (no reactive markers involved)', () => {
+    const out = processConditionals('@if(a)X@if(b)Y@else Z@endif W@endif', { a: true, b: false }, filePath)
+    expect(out).toContain('X')
+    expect(out).toContain('Z')
+    expect(out).toContain('W')
+    expect(out).not.toContain('Y')
+  })
+
+  it('does not skip a real directive @else that immediately follows a closing tag', () => {
+    const out = processConditionals('@if(show)<p>hi</p>@else<p>bye</p>@endif', { show: false }, filePath)
+    expect(out).toContain('<p>bye</p>')
+    expect(out).not.toContain('<p>hi</p>')
   })
 })


### PR DESCRIPTION
## Problem

A nested **reactive** `@if/@else` (client signal) inside a **server** `@if` corrupts the rendered template — content after the inner block and the outer `@else` branch get dropped, and the output is truncated mid-tag.

Minimal repro (two passes, the same order `processDirectives` uses):

```ts
const tpl = `<script>const isPro = state(false)</script>`
  + `<div>@if (ownsActive)BEFORE@if (isPro())PRO@else FREE@endif AFTER@else LOCKED@endif</div>`
processConditionals(convertSignalDirectivesToAttributes(tpl, { ownsActive: true }), { ownsActive: true }, 't.stx')
// before: <div>BEFORE<template @if="isPro()">PRO</template> <template </div>   ← truncated, AFTER dropped
// after:  <div>BEFORE<template @if="isPro()">PRO</template> <template @else>FREE</template> AFTER</div>
```

## Root cause

`convertSignalDirectivesToAttributes` (signal pass) rewrites the inner *reactive* conditional into HTML-attribute markers — `<template @if="isPro()">…</template><template @else>…</template>` — **before** `processConditionals` runs. `parseConditionalBlock`'s branch scanner then walks the outer **server** `@if` body textually and matches that `@else` **attribute** as the outer block's top-level `@else`. Its open-test requires `@if\s*\(` (so the `@if="…"` attribute isn't counted as a nested open), but its else-test `/^@else(?![a-z])/` happily matches `@else` inside `<template @else>`. The asymmetry unbalances branch/`@endif` boundaries.

## Fix

Directive tokens only ever occur in text content, never inside a `<...>` tag. Add `isInsideTag()` and skip tag-interior `@if/@elseif/@else/@endif` in the branch scanner so the signal and conditional passes agree on what is a directive.

## Tests

Adds regression tests (two-pass signal→conditionals) for both outer branches, an inner reactive `@elseif` chain, plus guards that normal server nesting and a directive `@else` right after a closing tag still work. Existing conditionals + parser + signal suites all green (871 pass / 0 fail); lint + typecheck clean.

Found while building nested owner-vs-share-mode conditionals in a downstream app (ghostanalytics dashboard).