### PR TITLE
fix(router): stop executing data scripts on a fragment swap

### DIFF
--- a/packages/router/src/client.ts
+++ b/packages/router/src/client.ts
@@ -503,6 +503,22 @@ else {
         var fragCrosswindHrefs=[];
         var fragCrosswindCSS=null;
         var cleanFrag=html.replace(new RegExp('<scr'+'ipt\\\\b([^>]*)>([\\\\s\\\\S]*?)<\\\\/scr'+'ipt>','gi'),function(m,attrs,code){
+          // A data block is not code, and everything below this line assumes it
+          // is: the body gets stashed in fragScripts, re-emitted as a pending
+          // placeholder, then wrapped in braces and executed. Wrapping a JSON
+          // object in braces reparses it as a labelled block, so its first ':'
+          // is a SyntaxError on every single fragment swap
+          // (stacksjs/stx#1801). @structuredData renders at its call site,
+          // which inside a layout is @section('content') — i.e. in the routed
+          // container — so the natural way to write it hit this.
+          //
+          // Left exactly as found rather than stripped: crawlers read
+          // structured data wherever it sits, and the browser will not execute
+          // a non-JS type anyway. Mirrors prepareRoutedBodyScripts' notion of
+          // executable, which this path never had.
+          var typeMatch=attrs.match(/\\btype\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))/i);
+          var scriptType=((typeMatch&&(typeMatch[1]||typeMatch[2]||typeMatch[3]))||'').trim().toLowerCase();
+          if(scriptType&&scriptType!=='text/javascript'&&scriptType!=='application/javascript'&&scriptType!=='module')return m;
           if(code&&code.trim()&&!isSignalsRuntimeScript({hasAttribute:function(name){return name==='data-stx-runtime'&&attrs.indexOf('data-stx-runtime')!==-1}},code)){
             var slot='fragment-'+(++fragScriptId);
             var scoped=/(?:^|\\s)data-stx-scoped(?:\\s|=|$)/i.test(attrs);

--- a/packages/router/test/client-data-scripts.test.ts
+++ b/packages/router/test/client-data-scripts.test.ts
@@ -1,0 +1,167 @@
+/**
+ * A data block is not code (stacksjs/stx#1801).
+ *
+ * `doFragSwap` pulls scripts out of an incoming fragment with a regex over the
+ * raw HTML, and every match was treated as JavaScript: stashed, re-emitted as a
+ * pending placeholder, then wrapped in braces and executed. Wrapping a JSON
+ * object in braces reparses it as a labelled block, so its first `:` throws
+ * `SyntaxError: Unexpected token ':'` — once per fragment swap, on every
+ * navigation into the page.
+ *
+ * It stayed hidden because the swap still completes and the page looks correct;
+ * it is only visible with the console open. The reporter found it after a full
+ * stage of work had already shipped over it.
+ *
+ * `prepareRoutedBodyScripts` classifies by `type` and the head/body collection
+ * requires a setup marker, so both of those paths were already safe. The regex
+ * path never had the check — which is why the two obvious suspects looked
+ * innocent when the issue was filed.
+ *
+ * `@structuredData` renders at its call site, and inside a layout that is
+ * `@section('content')` — i.e. within the routed container. So the natural way
+ * to write it triggered this, including the breadcrumb example in the guide.
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { Window } from 'very-happy-dom'
+import { getRouterScript } from '../src/client'
+
+const originalGlobals = {
+  window: globalThis.window,
+  document: globalThis.document,
+  location: globalThis.location,
+  history: globalThis.history,
+  fetch: globalThis.fetch,
+  CustomEvent: globalThis.CustomEvent,
+  Event: globalThis.Event,
+  DOMParser: globalThis.DOMParser,
+}
+
+afterEach(() => {
+  Object.assign(globalThis, originalGlobals)
+})
+
+const PAGE = `
+  <html>
+    <head>
+      <meta name="stx-layout" content="layouts/app.stx">
+      <meta name="stx-layout-group" content="app">
+    </head>
+    <body><main>Home</main></body>
+  </html>
+`
+
+/** Same layout group on both sides, so navigation takes the fragment path. */
+function installRouter(fragmentHtml: string) {
+  const window = new Window({ url: 'http://localhost/' })
+  window.document.write(PAGE)
+  ;(window as any).stx = {}
+  ;(window as any).__stxRouterConfig = {
+    cache: false,
+    prefetch: false,
+    progress: false,
+    viewTransitions: false,
+  }
+
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    location: window.location,
+    history: window.history,
+    CustomEvent: window.CustomEvent,
+    Event: window.Event,
+    DOMParser: window.DOMParser,
+    fetch: async () => new Response(fragmentHtml, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html',
+        'X-STX-Fragment': 'true',
+        'X-STX-Layout': 'layouts/app.stx',
+        'X-STX-Layout-Group': 'app',
+      },
+    }),
+  })
+
+  new Function(getRouterScript())()
+  return window as Window & { stxRouter: any }
+}
+
+async function navigate(window: any, url: string) {
+  await window.stxRouter.navigate(url)
+  await new Promise(r => setTimeout(r, 200))
+}
+
+const LD_JSON = '{"@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1}]}'
+
+describe('router — non-executable scripts in a swapped fragment', () => {
+  it('does not brace-wrap a JSON-LD payload', async () => {
+    // The wrap is what threw. Reproduce it directly so the premise is pinned:
+    // if this ever stops throwing, the guard below is testing nothing.
+    expect(() => new Function(`{${LD_JSON}}`)).toThrow()
+
+    const window = installRouter(
+      `<section><script type="application/ld+json">${LD_JSON}<\/script><h1>Pricing</h1></section>`,
+    )
+    await navigate(window, '/pricing')
+
+    const injected = Array.from(window.document.querySelectorAll('script[data-stx-page]'))
+      .map((s: any) => s.textContent || '')
+    expect(injected.some(t => t.includes('BreadcrumbList'))).toBe(false)
+  })
+
+  it('leaves the structured data in the document for crawlers', async () => {
+    // Stripping it would trade a console error for an SEO regression, so the
+    // guard preserves the node verbatim rather than dropping it.
+    const window = installRouter(
+      `<section><script type="application/ld+json">${LD_JSON}<\/script><h1>Pricing</h1></section>`,
+    )
+    await navigate(window, '/pricing')
+
+    const ld = window.document.querySelector('script[type="application/ld+json"]')
+    expect(ld).toBeTruthy()
+    expect(ld?.textContent).toContain('BreadcrumbList')
+    // And it must not have been rewritten into the router's pending placeholder.
+    expect(ld?.getAttribute('data-stx-route-script')).toBeNull()
+  })
+
+  it('survives repeated navigation, which is when the error fired', async () => {
+    const window = installRouter(
+      `<section><script type="application/ld+json">${LD_JSON}<\/script><h1>Page</h1></section>`,
+    )
+    await navigate(window, '/pricing')
+    await navigate(window, '/features')
+
+    const injected = Array.from(window.document.querySelectorAll('script[data-stx-page]'))
+      .map((s: any) => s.textContent || '')
+    expect(injected.some(t => t.includes('BreadcrumbList'))).toBe(false)
+  })
+
+  it('still executes real page scripts in the same fragment', async () => {
+    // The guard must not become a blanket skip: a JSON-LD block sitting next to
+    // a page script is the actual shape of an SEO'd page.
+    const window = installRouter(
+      `<section>`
+      + `<script type="application/ld+json">${LD_JSON}<\/script>`
+      + `<script data-stx-run="always">SENTINEL_EXEC()<\/script>`
+      + `</section>`,
+    )
+    await navigate(window, '/pricing')
+
+    const injected = Array.from(window.document.querySelectorAll('script[data-stx-page]'))
+      .map((s: any) => s.textContent || '')
+    expect(injected.some(t => t.includes('SENTINEL_EXEC'))).toBe(true)
+  })
+
+  it('treats other data types the same way', async () => {
+    // importmap and speculationrules are JSON too, and an importmap executed as
+    // JS would break module resolution for the whole document.
+    const window = installRouter(
+      `<section><script type="importmap">{"imports":{"a":"/a.js"}}<\/script><h1>Page</h1></section>`,
+    )
+    await navigate(window, '/pricing')
+
+    const injected = Array.from(window.document.querySelectorAll('script[data-stx-page]'))
+      .map((s: any) => s.textContent || '')
+    expect(injected.some(t => t.includes('imports'))).toBe(false)
+    expect(window.document.querySelector('script[type="importmap"]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Fixes #1801.

## The line you couldn't pin

The issue says: *"I could not conclusively prove which of these admits the node — the `newContent.contains(s)` check looks like it should exclude an in-container script, so my model is incomplete."*

That instinct was right. **Both quoted sites are innocent.** `prepareRoutedBodyScripts` classifies by `type`, and the head/body collection requires a setup marker *and* `!newContent.contains(s)`. Neither can admit an in-container `ld+json`.

The culprit is a **third** site the issue doesn't quote — and it's the one the stack trace actually names. `doFragSwap` extracts scripts with a **regex over the raw HTML string**, not the DOM:

```js
// client.ts:505 — no type guard, unlike the DOM path
html.replace(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi, function (m, attrs, code) {
  if (code && code.trim() && !isSignalsRuntimeScript(...)) {
    fragScripts.push({ text: code, ... })
    return '<script type="application/stx-pending" data-stx-route-script="' + slot + '">' + code + '</script>'
  }
  return ''
})
```

Full chain, matching the reported trace exactly:

| step | line | what happens |
|---|---|---|
| regex match | 505 | `ld+json` captured as if it were JS |
| placeholder emitted | 514 | rewritten to `application/stx-pending`, JSON kept as body |
| `innerHTML = cleanFrag` | 574 | placeholder lands in the container |
| `fragScripts.forEach` | 586 | `doFragSwap` → `Array.forEach` frame |
| brace wrap | 638 | `'{' + code + '}'` |
| `replaceChild` | 642 | **SyntaxError: Unexpected token ':'** |

## The fix

A type guard mirroring the one `prepareRoutedBodyScripts` already has, and **returning the node untouched** rather than stripping it — crawlers read structured data wherever it sits, and the browser won't execute a non-JS type anyway.

Covers `importmap` and `speculationrules` for free. That matters: an importmap executed as JS would break module resolution for the entire document.

## Verification

5 regression tests, and I confirmed they fail without the guard (**3 of 5 fail**, the other two being the does-not-overreach cases). Full router suite: **116 pass, 0 fail**. pickier clean.

The tests also pin the premise directly — `expect(() => new Function('{' + LD_JSON + '}')).toThrow()` — so if brace-wrapping ever stops throwing, the guard isn't silently testing nothing.

## Note on the workaround

The `@push('scripts')` workaround in the issue is still fine, but shouldn't be needed after this. Worth keeping in mind that `@structuredData` renders at its call site, so inside a layout it lands in `@section('content')` — the guide's own ch. 4.9 breadcrumb example produces exactly the shape that triggered this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)