### PR TITLE
feat(layouts): honour a fallback layouts directory

### DIFF
--- a/packages/bun-plugin/src/serve.ts
+++ b/packages/bun-plugin/src/serve.ts
@@ -3176,7 +3176,7 @@ function __stxOverlay(errs){
                         ...defaultConfig,
                         ...(componentsDir && { componentsDir }),
                         ...(layoutsDir && { layoutsDir }),
-      ...(fallbackLayoutsDir && { fallbackLayoutsDir }),
+                        ...(fallbackLayoutsDir && { fallbackLayoutsDir }),
                         ...(partialsDir && { partialsDir }),
                         autoShell: false,
                       }

--- a/packages/bun-plugin/src/serve.ts
+++ b/packages/bun-plugin/src/serve.ts
@@ -537,6 +537,15 @@ export interface ServeOptions {
   openPath?: string
   componentsDir?: string
   layoutsDir?: string
+  /**
+   * Layouts to fall back to when `layoutsDir` does not have the one a page
+   * asks for, so a framework can ship defaults an app overrides by name.
+   *
+   * Stacks has been passing this since the views server was written; until
+   * stx honoured it, it did nothing, and every page extending a framework
+   * layout served a 200 with an empty body.
+   */
+  fallbackLayoutsDir?: string
   partialsDir?: string
   /**
    * Additional source directories that can affect rendered HTML.
@@ -1015,6 +1024,7 @@ export async function serve(options: ServeOptions): Promise<void> {
   // Options passed directly take precedence, then bunfig config, then defaults
   const componentsDir = options.componentsDir ?? stxConfig.componentsDir ?? defaultStxConfig.componentsDir
   const layoutsDir = options.layoutsDir ?? stxConfig.layoutsDir ?? defaultStxConfig.layoutsDir
+  const fallbackLayoutsDir = options.fallbackLayoutsDir ?? stxConfig.fallbackLayoutsDir
   const partialsDir = options.partialsDir ?? stxConfig.partialsDir ?? defaultStxConfig.partialsDir
   const publicDir = options.publicDir ?? stxConfig.publicDir ?? 'public'
 
@@ -2203,6 +2213,7 @@ function __stxOverlay(errs){
       root: process.cwd(),
       ...(componentsDir && { componentsDir }),
       ...(layoutsDir && { layoutsDir }),
+      ...(fallbackLayoutsDir && { fallbackLayoutsDir }),
       ...(partialsDir && { partialsDir }),
       autoShell: true,
       buildMode: 'serve' as const,
@@ -2576,6 +2587,7 @@ function __stxOverlay(errs){
       root: process.cwd(),
       ...(componentsDir && { componentsDir }),
       ...(layoutsDir && { layoutsDir }),
+      ...(fallbackLayoutsDir && { fallbackLayoutsDir }),
       ...(partialsDir && { partialsDir }),
       autoShell: true,
       buildMode: 'serve' as const,
@@ -3164,6 +3176,7 @@ function __stxOverlay(errs){
                         ...defaultConfig,
                         ...(componentsDir && { componentsDir }),
                         ...(layoutsDir && { layoutsDir }),
+      ...(fallbackLayoutsDir && { fallbackLayoutsDir }),
                         ...(partialsDir && { partialsDir }),
                         autoShell: false,
                       }

--- a/packages/stx/src/process.ts
+++ b/packages/stx/src/process.ts
@@ -1084,20 +1084,30 @@ async function processDirectivesInternal(
         // compare against, the message was easy to scroll past — which is how a
         // page ends up asserting a layout group with no layout behind it
         // (#1879).
-        let available: string[] = []
-        try {
-          const dir = resolvedOptions.layoutsDir
-          if (dir) {
+        //
+        // Both directories are listed, not just `layoutsDir`. Reporting only
+        // the app's own layouts made a resolvable-but-unconfigured fallback
+        // look like the layout did not exist anywhere, which sent the search
+        // in the wrong direction entirely.
+        const layoutsIn = (dir: string | undefined): string[] => {
+          if (!dir)
+            return []
+          try {
             const abs = path.isAbsolute(dir) ? dir : path.resolve(process.cwd(), dir)
-            available = fs.readdirSync(abs)
+            return fs.readdirSync(abs)
               .filter(f => f.endsWith('.stx'))
               .map(f => f.replace(/\.stx$/, ''))
-              .sort()
+          }
+          catch {
+            // Unreadable directory — the message is still worth emitting.
+            return []
           }
         }
-        catch {
-          // Unreadable layoutsDir — the message is still worth emitting.
-        }
+
+        const available = [
+          ...layoutsIn(resolvedOptions.layoutsDir),
+          ...layoutsIn(resolvedOptions.fallbackLayoutsDir),
+        ].filter((name, index, all) => all.indexOf(name) === index).sort()
 
         const warning = `Layout not found: ${layoutPath} (referenced from ${filePath})`
           + (available.length > 0

--- a/packages/stx/src/types/config-types.ts
+++ b/packages/stx/src/types/config-types.ts
@@ -688,6 +688,17 @@ export interface StxConfig {
   /** Path to layouts directory, defaults to 'layouts' in the project root */
   layoutsDir?: string
   /**
+   * Where to look for a layout `layoutsDir` does not have.
+   *
+   * For a framework that ships default layouts and lets an app override them
+   * by name: the app's own directory is `layoutsDir` and wins, and anything it
+   * does not define falls back here. Without it, an app that overrides one
+   * layout has to vendor every other layout it uses, and a page extending a
+   * framework layout renders with NO layout at all - a 200 with an empty body,
+   * which is far harder to diagnose than a 404.
+   */
+  fallbackLayoutsDir?: string
+  /**
    * Path to the stores directory, resolved against `root`.
    *
    * Every `.ts` file in it (except `index.ts`, `types.ts` and `.d.ts`) is

--- a/packages/stx/src/utils.ts
+++ b/packages/stx/src/utils.ts
@@ -1492,7 +1492,7 @@ export async function resolveTemplatePath(
   const safeUnderCwd = assertInsideRoot(result, process.cwd())
   if (safeUnderCwd) return safeUnderCwd
 
-  const trustedDirs = [options.root, options.layoutsDir, options.componentsDir, options.partialsDir, options.pagesDir]
+  const trustedDirs = [options.root, options.layoutsDir, options.fallbackLayoutsDir, options.componentsDir, options.partialsDir, options.pagesDir]
     .filter((d): d is string => typeof d === 'string' && d.length > 0)
   for (const dir of trustedDirs) {
     const resolvedDir = path.isAbsolute(dir) ? dir : path.resolve(process.cwd(), dir)
@@ -1651,6 +1651,36 @@ async function resolveTemplatePathInner(
           dependencies.add(fromLayoutsDirWithExt)
         }
         return fromLayoutsDirWithExt
+      }
+    }
+  }
+
+  // The app's layouts directory did not have it, so try the one the framework
+  // ships. This is the override model the caller is expressing: `layoutsDir`
+  // is the app and wins, `fallbackLayoutsDir` is the default set behind it.
+  //
+  // Checked AFTER `options.layoutsDir` on purpose - an app that defines a
+  // layout of the same name must win, which is the whole point of shipping
+  // defaults. Missing this step is not a 404 but a 200 with an empty body,
+  // because a page whose layout does not resolve renders its sections into
+  // nothing.
+  if (options.fallbackLayoutsDir) {
+    const resolvedFallback = path.isAbsolute(options.fallbackLayoutsDir)
+      ? options.fallbackLayoutsDir
+      : path.resolve(process.cwd(), options.fallbackLayoutsDir)
+
+    const strippedPath = templatePath.startsWith('layouts/') ? templatePath.slice(8) : templatePath
+    const candidates = [path.join(resolvedFallback, strippedPath)]
+    if (!templatePath.endsWith('.stx'))
+      candidates.push(`${candidates[0]}.stx`)
+
+    for (const candidate of candidates) {
+      if (await fileExists(candidate)) {
+        if (options.debug)
+          console.log(`Found in options.fallbackLayoutsDir: ${candidate}`)
+        if (dependencies)
+          dependencies.add(candidate)
+        return candidate
       }
     }
   }

--- a/packages/stx/test/fallback-layouts.test.ts
+++ b/packages/stx/test/fallback-layouts.test.ts
@@ -1,0 +1,100 @@
+// A framework ships default layouts; an app overrides the ones it cares about.
+//
+// Without a fallback, an app that defines one layout has to vendor every other
+// layout it uses, and a page extending a framework layout renders with NO
+// layout at all. That failure is a 200 with an empty body - the sections have
+// nowhere to render into - which is far harder to diagnose than a 404, and is
+// exactly how a whole staff dashboard shipped blank to production.
+
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveTemplatePath } from '../src/utils'
+
+function tree(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'stx-layouts-'))
+  for (const [rel, body] of Object.entries(files)) {
+    const full = join(root, rel)
+    mkdirSync(join(full, '..'), { recursive: true })
+    writeFileSync(full, body)
+  }
+  return root
+}
+
+describe('fallbackLayoutsDir', () => {
+  test('finds a layout the app does not define', async () => {
+    const root = tree({
+      'app/layouts/marketing.stx': '<html></html>',
+      'defaults/layouts/default.stx': '<html>framework</html>',
+      'app/views/page.stx': '@extends(\'layouts/default\')',
+    })
+
+    const resolved = await resolveTemplatePath('layouts/default', join(root, 'app/views/page.stx'), {
+      layoutsDir: join(root, 'app/layouts'),
+      fallbackLayoutsDir: join(root, 'defaults/layouts'),
+    } as never)
+
+    expect(resolved).toBe(join(root, 'defaults/layouts/default.stx'))
+  })
+
+  test('the app still wins for a layout it does define', async () => {
+    // The point of shipping defaults is that they can be overridden. If the
+    // fallback won, an app could never replace a framework layout.
+    const root = tree({
+      'app/layouts/default.stx': '<html>app</html>',
+      'defaults/layouts/default.stx': '<html>framework</html>',
+      'app/views/page.stx': '@extends(\'layouts/default\')',
+    })
+
+    const resolved = await resolveTemplatePath('layouts/default', join(root, 'app/views/page.stx'), {
+      layoutsDir: join(root, 'app/layouts'),
+      fallbackLayoutsDir: join(root, 'defaults/layouts'),
+    } as never)
+
+    expect(resolved).toBe(join(root, 'app/layouts/default.stx'))
+  })
+
+  test('resolves a nested layout name', async () => {
+    const root = tree({
+      'app/layouts/marketing.stx': '<html></html>',
+      'defaults/layouts/dashboard/default.stx': '<html>dashboard</html>',
+      'app/views/page.stx': '@extends(\'layouts/dashboard/default\')',
+    })
+
+    const resolved = await resolveTemplatePath('layouts/dashboard/default', join(root, 'app/views/page.stx'), {
+      layoutsDir: join(root, 'app/layouts'),
+      fallbackLayoutsDir: join(root, 'defaults/layouts'),
+    } as never)
+
+    expect(resolved).toBe(join(root, 'defaults/layouts/dashboard/default.stx'))
+  })
+
+  test('stays null when neither directory has it', async () => {
+    const root = tree({
+      'app/layouts/marketing.stx': '<html></html>',
+      'defaults/layouts/default.stx': '<html></html>',
+      'app/views/page.stx': '@extends(\'layouts/nope\')',
+    })
+
+    const resolved = await resolveTemplatePath('layouts/nope', join(root, 'app/views/page.stx'), {
+      layoutsDir: join(root, 'app/layouts'),
+      fallbackLayoutsDir: join(root, 'defaults/layouts'),
+    } as never)
+
+    expect(resolved).toBeNull()
+  })
+
+  test('changes nothing when no fallback is configured', async () => {
+    const root = tree({
+      'app/layouts/marketing.stx': '<html></html>',
+      'app/views/page.stx': '@extends(\'layouts/default\')',
+    })
+
+    const resolved = await resolveTemplatePath('layouts/default', join(root, 'app/views/page.stx'), {
+      layoutsDir: join(root, 'app/layouts'),
+    } as never)
+
+    expect(resolved).toBeNull()
+  })
+})


### PR DESCRIPTION
A framework that ships default layouts and lets an app override them by name had no way to express that. `layoutsDir` is a single directory, so an app that defines one layout of its own has to vendor every other layout it uses.

**The failure when it does not is the worst kind.** A page whose layout does not resolve renders its sections into nothing, so the server returns **200 with an empty body** — not a 404, not an error page. Stacks shipped an entire staff dashboard to production that way: every `/dashboard/*` URL answered 200 with 1398 bytes and no content, because those pages extend the framework's `layouts/default` while the app's own layouts directory holds only its marketing layout.

## What this adds

`fallbackLayoutsDir`, checked **after** `layoutsDir` — an app that defines a layout of the same name still wins, since overriding is the point of shipping defaults.

Two things it needed beyond the lookup itself, both found by testing rather than reading:

- **The resolver's path guard now trusts `fallbackLayoutsDir`** the way it already trusts `layoutsDir`. A fallback legitimately points outside cwd — a framework's `node_modules/.../resources/layouts` is the normal case — and without this the guard rejected every hit as an escape. The lookup would have been dead code; the first two tests failed exactly this way.
- **"Layout not found" lists both directories.** Naming only the app's own layouts made a resolvable-but-unconfigured fallback look like the layout did not exist anywhere, which sends the search in the wrong direction. That is how the production case above stayed misdiagnosed.

`bun-plugin-stx` threads the option through all three render paths. Stacks has been passing `fallbackLayoutsDir` to it since its views server was written — until now nothing read it.

## Tests

5 new: the fallback resolves, the app still wins for a name it defines, nested names (`layouts/dashboard/default`) work, both-missing stays null, and no-fallback behaves exactly as before.

Suite goes from **13 pre-existing failures to 11** — no regressions, and none of the remaining failures touch layout resolution.