### PR TITLE
fix(router): a click the page already handled is not a navigation

### DIFF
--- a/packages/router/src/client.ts
+++ b/packages/router/src/client.ts
@@ -1355,6 +1355,21 @@ else {
   // mode where every page is part of the same SPA shell.
   document.addEventListener('click',function(e){
     if(e.metaKey||e.ctrlKey||e.shiftKey||e.altKey||e.button!==0)return;
+    // A handler on the page has already decided this click is not a
+    // navigation, so the router must not perform one - the same contract the
+    // browser honours for a plain anchor.
+    //
+    // This listener used to run in the CAPTURE phase, which broke that twice
+    // over: it saw the click before the anchor did, so defaultPrevented was
+    // necessarily false by the time it was read here, and the stopPropagation
+    // below then stopped the event ever reaching the element - so a page's own
+    // click handler on an intercepted link never ran AT ALL. Progressive
+    // enhancement on an anchor was impossible; the only way out was to swap it
+    // for a button in script (stacksjs/stacks#2393).
+    //
+    // Bubbling instead puts the page's handlers first, which is where a
+    // decision about the page's own markup belongs.
+    if(e.defaultPrevented)return;
     if(!e.target||!e.target.closest)return;
     var link=e.target.closest('[data-stx-link]');
     // A marked link still has to clear the opt-out set. It used to skip it
@@ -1372,7 +1387,7 @@ else {
     e.stopPropagation();
     log('[router] navigating to:',href);
     navigate(withCurrentLocale(href));
-  },true);
+  });
 
   // ── Form submission ──
   // A submit IS a navigation, and the router only ever watched clicks. So any

--- a/packages/router/test/link-preventdefault.test.ts
+++ b/packages/router/test/link-preventdefault.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The router must not navigate a click the page already handled
+ * (stacksjs/stacks#2393).
+ *
+ * The click listener ran in the CAPTURE phase, which broke the contract twice
+ * over. It saw the click before the anchor did, so `e.defaultPrevented` was
+ * necessarily false by the time the router read it - and it read it only to
+ * log it, never to branch on it. Worse, the `stopPropagation()` it then called
+ * stopped the event ever reaching the element, so a page's own click handler
+ * on an intercepted link never ran at all: not a late handler, not a losing
+ * handler, no handler.
+ *
+ * The visible symptom was an anchor that navigated away instead of opening the
+ * inline form its handler was there to render. The only workaround was to
+ * replace the anchor with a <button> in script, which costs the no-JS reader
+ * the link.
+ *
+ * Each case is paired with a control that must STILL be intercepted. A probe
+ * reporting "not intercepted" for both is measuring nothing.
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { Window } from 'very-happy-dom'
+import { getRouterScript } from '../src/client'
+
+const originalGlobals = {
+  window: globalThis.window,
+  document: globalThis.document,
+  location: globalThis.location,
+  history: globalThis.history,
+  fetch: globalThis.fetch,
+  CustomEvent: globalThis.CustomEvent,
+  Event: globalThis.Event,
+  MouseEvent: globalThis.MouseEvent,
+  DOMParser: globalThis.DOMParser,
+}
+
+afterEach(() => {
+  Object.assign(globalThis, originalGlobals)
+})
+
+interface Harness {
+  window: any
+  /** URLs the router actually fetched, i.e. navigations it claimed. */
+  navigations: string[]
+}
+
+function installRouter(body: string, config: Record<string, unknown> = {}): Harness {
+  const navigations: string[] = []
+  const window = new Window({ url: 'http://localhost/' })
+  window.document.write(`<html><head></head><body><main>Home</main>${body}</body></html>`)
+  ;(window as any).stx = {}
+  ;(window as any).__stxRouterConfig = {
+    cache: false,
+    prefetch: false,
+    progress: false,
+    viewTransitions: false,
+    ...config,
+  }
+
+  Object.assign(globalThis, {
+    window,
+    document: window.document,
+    location: window.location,
+    history: window.history,
+    CustomEvent: window.CustomEvent,
+    Event: window.Event,
+    MouseEvent: window.MouseEvent,
+    DOMParser: window.DOMParser,
+    fetch: async (url: string) => {
+      navigations.push(String(url))
+      return new Response('<section>next</section>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      })
+    },
+  })
+
+  new Function(getRouterScript())()
+
+  return { window, navigations }
+}
+
+function click(harness: Harness, selector: string): void {
+  const element = harness.window.document.querySelector(selector)
+  if (!element)
+    throw new Error(`no element matched ${selector}`)
+  element.dispatchEvent(new harness.window.MouseEvent('click', { bubbles: true, cancelable: true }))
+}
+
+/** Binds the progressive-enhancement handler the issue describes. */
+function enhance(harness: Harness, selector: string, ran: { value: boolean }): void {
+  harness.window.document.querySelector(selector).addEventListener('click', (event: any) => {
+    ran.value = true
+    event.preventDefault()
+  })
+}
+
+describe('a page handler that cancels the click (#2393)', () => {
+  describe('a marked [data-stx-link] anchor', () => {
+    it('control: without a handler the router still claims it', () => {
+      const harness = installRouter(`<a id="t" data-stx-link href="/partner">Go</a>`)
+      click(harness, '#t')
+      expect(harness.navigations).toEqual(['/partner'])
+    })
+
+    it('runs the page handler at all', () => {
+      // Under capture + stopPropagation the event never reached the anchor,
+      // so this was false: the handler did not lose the race, it never ran.
+      const harness = installRouter(`<a id="t" data-stx-link href="/partner">Go</a>`)
+      const ran = { value: false }
+      enhance(harness, '#t', ran)
+      click(harness, '#t')
+      expect(ran.value).toBe(true)
+    })
+
+    it('does not navigate once that handler has cancelled it', () => {
+      const harness = installRouter(`<a id="t" data-stx-link href="/partner">Go</a>`)
+      enhance(harness, '#t', { value: false })
+      click(harness, '#t')
+      expect(harness.navigations).toEqual([])
+    })
+  })
+
+  describe('an ordinary anchor under interceptAllLinks', () => {
+    const staticSite = { interceptAllLinks: true }
+
+    it('control: without a handler the router still claims it', () => {
+      const harness = installRouter(`<a id="t" href="/partner">Go</a>`, staticSite)
+      click(harness, '#t')
+      expect(harness.navigations).toEqual(['/partner'])
+    })
+
+    it('runs the page handler at all', () => {
+      const harness = installRouter(`<a id="t" href="/partner">Go</a>`, staticSite)
+      const ran = { value: false }
+      enhance(harness, '#t', ran)
+      click(harness, '#t')
+      expect(ran.value).toBe(true)
+    })
+
+    it('does not navigate once that handler has cancelled it', () => {
+      const harness = installRouter(`<a id="t" href="/partner">Go</a>`, staticSite)
+      enhance(harness, '#t', { value: false })
+      click(harness, '#t')
+      expect(harness.navigations).toEqual([])
+    })
+
+    it('leaves an uncancelled handler on a sibling link alone', () => {
+      // The guard reads the event, not the element, so one enhanced link must
+      // not stop the next plain one from routing.
+      const harness = installRouter(
+        `<a id="a" href="/partner">Claim</a><a id="b" href="/browse">Browse</a>`,
+        staticSite,
+      )
+      enhance(harness, '#a', { value: false })
+      click(harness, '#a')
+      click(harness, '#b')
+      expect(harness.navigations).toEqual(['/browse'])
+    })
+  })
+})


### PR DESCRIPTION
Fixes stacksjs/stacks#2393.

## The bug is worse than reported

The issue says the router ignores `preventDefault` and that "the handler does run". It doesn't. A probe against the real router script:

```
>> page handler ran: false
>> router fetched  : ["/partner"]
```

**A page's own click handler on an intercepted link never runs at all.**

## Root cause

The SPA click listener was registered on `document` in the **capture** phase:

```js
document.addEventListener('click',function(e){
  ...
  log('[router] click intercepted:',href,'container:',!!getContainer(),'defaultPrevented:',e.defaultPrevented);
  e.preventDefault();
  e.stopPropagation();
  navigate(withCurrentLocale(href));
},true);   // <- capture
```

Two consequences, and they compound:

1. **Capture runs before the target.** So `e.defaultPrevented` is necessarily `false` when the router reads it. Note the log line: the value was read *only to print it*, never to branch on. Adding a guard without leaving capture would have fixed nothing.
2. **`stopPropagation()` in capture stops the event ever reaching the element.** That is why the handler never runs - it is not losing a race, it is never dispatched.

The `,true` has been there since the listener was first drafted, in a `chore: wip` commit, with no comment justifying it. It does not look like a considered decision.

## Blast radius

Both intercept paths: a marked `[data-stx-link]` anchor, and any same-origin anchor under `interceptAllLinks` - which is how static-site mode serves every page. Any anchor meant to open a panel, dialog or inline form navigated away instead, and the workaround was to replace it with a `<button>` in script, which costs the no-JS reader the link.

By the same mechanism this also swallowed anything else bound to an intercepted anchor, since `stopPropagation` does not care who registered the listener.

## The fix

Bubble instead of capture, and return early on a cancelled click. The page's handlers run first, which is where a decision about the page's own markup belongs, and the router honours the same contract the browser does for a plain anchor.

## Verification

7 new tests in `packages/router/test/link-preventdefault.test.ts`, using the existing `very-happy-dom` harness that evaluates the real `getRouterScript()` and dispatches real events.

Each half of the fix is proven load-bearing by reverting it in isolation:

| variant | result |
|---|---|
| restore capture, keep the guard | **5 of 7 fail**, including `runs the page handler at all` |
| keep bubble, drop the guard | **3 of 7 fail** |
| both | 7 pass |

Every case is paired with a control that must **still** be intercepted, so a probe reporting "not intercepted" for both is not mistaken for a pass. One case covers a sibling link, since the guard reads the event rather than the element.

- Router suite: **239 pass / 0 fail** (baseline 232, +7 new).
- stx build + owned-routes: 130 pass / 0 fail.
- `typecheck` clean; `lint` 0 errors.

## Note for reviewers

One behaviour genuinely changes beyond the bug: a page handler that calls `stopPropagation()` without `preventDefault()` will now stop the router seeing the click, giving a full page load. That is the correct reading of `stopPropagation` and matches other SPA routers, but it is a real difference from capture-phase interception.